### PR TITLE
Copy latest esphome configs for zeroconf from tube_gateways by tube0013

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zeroconf custom component for ESPHome
 
 
-Example configuration:
+Example configuration without DNS TXT records:
 
 ```yaml
 zeroconf:
@@ -22,7 +22,7 @@ zeroconf:
 ```
 
 
-Adding some txt records for esphome-zbbridge gateway application version, location, and Zigbee radio configuration to be based along to ZHA integration:
+Now an example with also adding some DNS TXT records as parameters for esphome-zbbridge gateway application version, location, and Zigbee radio configuration to be based along to ZHA integration:
 
 ```yaml
 zeroconf:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ zeroconf:
  Result:
  
  ```
- _myservice._tcp      local
+ _esphome_zb_gw_efr32._tcp      local
    hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [6638]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Example configuration:
 
 ```yaml
 zeroconf:
-  - service: myservice
+  - service: esphome_zb_gw
     protocol: tcp
-    port: 8080
+    port: 6638
  ```
  
  
@@ -15,23 +15,26 @@ zeroconf:
  
  ```
  _myservice._tcp      local
-   hostname = [my_esphome_node.local]
+   hostname = [esphome_zb_gw.local]
    address = [172.16.0.174]
-   port = [8080]
+   port = [6638]
    txt = []
 ```
 
 
-Adding some txt records:
+Adding some txt records for esphome-zbbridge gateway application version, location, and Zigbee radio configuration to be based along to ZHA integration:
 
 ```yaml
 zeroconf:
-  - service: myservice
+  - service: esphome_zb_gw
     protocol: tcp
-    port: 8080
+    port: 6638
     txt:
       version: 1.0
       location: basement
+      radio_type: znp
+      baud_rate: 115200
+      data_flow_control: software
  ```
  
  
@@ -39,10 +42,10 @@ zeroconf:
  
  ```
  _myservice._tcp      local
-   hostname = [my_esphome_node.local]
+   hostname = [esphome_zb_gw.local]
    address = [172.16.0.174]
-   port = [8080]
-   txt = ["version=1.0" "location=basement"]
+   port = [6638]
+   txt = ["version=1.0" "location=basement" "radio_type=znp" "baud_rate=115200" "data_flow_control=software"]
 ```
 
 (Test results obtained with `avahi-browse -a -r`)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ zeroconf:
     txt:
       version: 1.0
       location: basement
-      radio_type: znp
+      radio_type: ezsp
       baud_rate: 115200
       data_flow_control: software
  ```
@@ -45,7 +45,7 @@ zeroconf:
    hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [6638]
-   txt = ["version=1.0" "location=basement" "radio_type=znp" "baud_rate=115200" "data_flow_control=software"]
+   txt = ["version=1.0" "location=basement" "radio_type=ezsp" "baud_rate=115200" "data_flow_control=software"]
 ```
 
 (Test results obtained with `avahi-browse -a -r`)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Example configuration:
 
 ```yaml
 zeroconf:
-  - service: esphome_zb_gw
+  - service: esphome_zb_gw_efr32
     protocol: tcp
     port: 6638
  ```
@@ -15,7 +15,7 @@ zeroconf:
  
  ```
  _myservice._tcp      local
-   hostname = [esphome_zb_gw.local]
+   hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [6638]
    txt = []
@@ -26,7 +26,7 @@ Adding some txt records for esphome-zbbridge gateway application version, locati
 
 ```yaml
 zeroconf:
-  - service: esphome_zb_gw
+  - service: esphome_zb_gw_efr32
     protocol: tcp
     port: 6638
     txt:
@@ -41,8 +41,8 @@ zeroconf:
  Result:
  
  ```
- _myservice._tcp      local
-   hostname = [esphome_zb_gw.local]
+ _esphome_zb_gw_efr32._tcp      local
+   hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [6638]
    txt = ["version=1.0" "location=basement" "radio_type=znp" "baud_rate=115200" "data_flow_control=software"]


### PR DESCRIPTION
With the exception of hostname and service name copy latest esphome configs for zeroconf from tube_gateways by tube0013 as it is so far only whitelisted Zigbee gateways in the ZHA integration component inside Home Assistant core repository:

https://www.home-assistant.io/integrations/zha#discovery-via-usb-or-zeroconf

https://github.com/tube0013/tube_gateways/tree/main/esphome

https://github.com/tube0013/tube_gateways/blob/ed3d541a29890699a6e8e9550af44c537712751d/V2_tube_zb_gw_cc2752p2/ESPHome/tube_zb_gw_cc2652p2v2.yml

https://github.com/tube0013/tube_gateways/blob/7bde5f09852b95fd98d146f659464678bd6ce2f9/tube_zb_gw_efr32/Firmware/ZigBee%20Module/V2_tube_zb_gw_cc2752p2/ESPHome/tube_zb_gw_cc2652p2v2.yml

